### PR TITLE
fix(languages): prechecks for node installations and fixes java

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -13,7 +13,7 @@
       tags:
       - javascript
       - all
-    - include: ./tasks/java.yaml
+    - include: ./tasks/java.yml
       tags:
       - java
       - all

--- a/tasks/java.yml
+++ b/tasks/java.yml
@@ -4,6 +4,7 @@
     state: present
   tags:
   - backend
+  - java_language
 - name: Install Java
   community.general.homebrew_cask:
     name: adoptopenjdk11
@@ -11,6 +12,7 @@
     accept_external_apps: true
   tags:
   - backend
+  - java_language
 - name: Install IntelliJ Idea
   community.general.homebrew_cask:
     name: intellij-idea

--- a/tasks/javascript.yml
+++ b/tasks/javascript.yml
@@ -6,11 +6,20 @@
   tags:
   - frontend
   - vscode
+- name: Check for Node Installation
+  shell: >
+    [ ! $(command -v node) ] | echo
+  register: node_install
+  tags:
+  - frontend
+  - node
+  - nvm
 - name: Install NVM
   shell: >
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | sh
   args:
     creates: "{{ ansible_env.HOME }}/.nvm/nvm.sh"
+  when: node_install|bool
   tags:
   - frontend
   - node
@@ -19,6 +28,7 @@
   shell: echo "typescript\nyarn\n" > "{{ ansible_env.HOME }}/.nvm/default-packages"
   args:
     creates: "{{ansible_env.HOME}}/.nvm/default-packages"
+  when: node_install|bool
   tags:
   - frontend
   - node
@@ -28,6 +38,7 @@
   shell: source {{ ansible_env.HOME }}/.nvm/nvm.sh && nvm install 14
   args:
     creates: "{{ansible_env.HOME}}/.nvm/alias"
+  when: node_install|bool
   tags:
   - frontend
   - node


### PR DESCRIPTION
I had the wrong file extension for Java, so it would error on every run

Adds a pre-check command for JavaScript that will check if node is installed, skipping the installation and configuration if it is.