### PR TITLE
refactor(ansible): replaces deprecated property 'includes'

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -1,19 +1,18 @@
 - hosts: ["localhost"]
   # become: true
   tasks:
-    - include: ./tasks/general.yml
+    - import_tasks: ./tasks/general.yml
       tags:
       - general
       - all
-    - include: ./tasks/extras.yml
+    - import_tasks: ./tasks/extras.yml
       tags:
       - extras
-      - all
-    - include: ./tasks/javascript.yml
+    - import_tasks: ./tasks/javascript.yml
       tags:
       - javascript
       - all
-    - include: ./tasks/java.yml
+    - import_tasks: ./tasks/java.yml
       tags:
       - java
       - all


### PR DESCRIPTION
The `include` property was deprecated.  Below are details from the docs

Removed in
version 2.16

Why
it has too many conflicting behaviours depending on keyword combinations and it was unclear how it should behave in each case. new actions were developed that were specific about each case and related behaviours.

Alternative
include_tasks, import_tasks, import_playbook