### PR TITLE
Add additional runner.sh steps for M1 macs

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -9,6 +9,28 @@ echo
 echo "This process will ask a few questions before performing a few provisional installations.  Once you see a message that says, 'Feel free to step away from your computer', you won't need to provide any more input as the process completes."
 sleep 2
 
+
+export IS_M1_MAC=false
+# To make sure we don't rely on native shell behavior, use sysctl to try to find the system
+# architecture: https://stackoverflow.com/a/69853058
+if sysctl -n machdep.cpu.brand_string 2> /dev/null | grep -q "^Apple M1"
+then
+    export IS_M1_MAC=true
+fi
+
+# If this is using an M1 Mac but is running a Rosetta-based program (either the shell or the
+# terminal), the `uname -p` will not return 'arm' and we'll know that Rosetta is already installed.
+# Otherwise there aren't very many good ways to check for Rosetta's installation.
+echo
+echo "Let's install Rosetta for M1 chip compatibility..."
+sleep 0.5
+
+if "$IS_M1_MAC" && [[ $(uname -p) == "arm" ]]
+then
+    sudo softwareupdate --install-rosetta
+fi
+
+
 echo
 echo "Let's check your git configuration..."
 sleep 0.5
@@ -56,16 +78,13 @@ then
 
     # Homebrew on M1 macs installs to /opt/homebrew instead of /usr/local, so won't be picked up
     # without some help
-    if [[ $(command -v brew) == "" ]] && sysctl -n machdep.cpu.brand_string 2> /dev/null | grep -q "^Apple M1"
+    if "$IS_M1_MAC" && command -v brew 2 > /dev/null
     then
         # Modify both the bash and zsh profiles to make sure the configuration gets picked up
         # regardless of shell
         echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> tee -a ~/.profile
         echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> tee -a ~/.zprofile
         eval "$(/opt/homebrew/bin/brew shellenv)"
-
-        # Many casks require Rosetta to be installed before they can run
-        sudo softwareupdate --install-rosetta
     fi
 else
     echo

--- a/runner.sh
+++ b/runner.sh
@@ -21,12 +21,12 @@ fi
 # If this is using an M1 Mac but is running a Rosetta-based program (either the shell or the
 # terminal), the `uname -p` will not return 'arm' and we'll know that Rosetta is already installed.
 # Otherwise there aren't very many good ways to check for Rosetta's installation.
-echo
-echo "Let's install Rosetta for M1 chip compatibility..."
-sleep 0.5
-
 if "$IS_M1_MAC" && [[ $(uname -p) == "arm" ]]
 then
+    echo
+    echo "Let's install Rosetta for M1 chip compatibility..."
+    sleep 0.5
+
     sudo softwareupdate --install-rosetta
 fi
 
@@ -78,7 +78,7 @@ then
 
     # Homebrew on M1 macs installs to /opt/homebrew instead of /usr/local, so won't be picked up
     # without some help
-    if "$IS_M1_MAC" && command -v brew 2 > /dev/null
+    if "$IS_M1_MAC" && command -v brew >/dev/null
     then
         # Modify both the bash and zsh profiles to make sure the configuration gets picked up
         # regardless of shell
@@ -91,6 +91,7 @@ else
     echo "Updating Homebrew..."
     brew update > /dev/null
 fi
+
 
 echo
 echo "Homebrew is ready for use"

--- a/runner.sh
+++ b/runner.sh
@@ -53,6 +53,20 @@ then
     echo
     echo "Installing Homebrew..."
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    # Homebrew on M1 macs installs to /opt/homebrew instead of /usr/local, so won't be picked up
+    # without some help
+    if [[ $(command -v brew) == "" ]] && sysctl -n machdep.cpu.brand_string 2> /dev/null | grep -q "^Apple M1"
+    then
+        # Modify both the bash and zsh profiles to make sure the configuration gets picked up
+        # regardless of shell
+        echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> tee -a ~/.profile
+        echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> tee -a ~/.zprofile
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+
+        # Many casks require Rosetta to be installed before they can run
+        sudo softwareupdate --install-rosetta
+    fi
 else
     echo
     echo "Updating Homebrew..."


### PR DESCRIPTION
Homebrew installs to a different location on M1 machines than on Intel. This new path is not on the PATH by default and requires modifying the user's shell configuration to add.

These commands were copy-pasted from the Homebrew install script's output, just doubled up to make sure that both zsh and bash user's were accounted for.

Some (maybe most?) casks also require Rosetta to be installed (such as the JVM); this is also added to the configuration.

This commit roughly mirrors the commands I ran manually to get my machine ready to run the remaining parts of the script.